### PR TITLE
fix bug: always return the same address (of index 0) with any pairIndex

### DIFF
--- a/src/Ripple.Signing/Seed.cs
+++ b/src/Ripple.Signing/Seed.cs
@@ -66,7 +66,7 @@ namespace Ripple.Signing
                 }
                 return EdKeyPair.From128Seed(_seedBytes);
             }
-            pairIndex = _isNodeKey ? -1 : 0;
+            pairIndex = _isNodeKey ? -1 : pairIndex;
             var pair = K256KeyGenerator.From128Seed(_seedBytes, pairIndex);
             if (_isNodeKey)
             {


### PR DESCRIPTION
- when I want to generate new address by index, it always return the same address (of index 0) even any input pairIndexs